### PR TITLE
Add joint_state_publisher_gui

### DIFF
--- a/osr_description/launch/visualize_robot.launch
+++ b/osr_description/launch/visualize_robot.launch
@@ -1,11 +1,8 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="gui" default="True" />
-  
   <param name="robot_description" command="$(find xacro)/xacro --inorder $(find osr_description)/urdf/denso_vs060_robot.urdf.xacro" />
   
-  <param name="use_gui" value="$(arg gui)"/>
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
   

--- a/osr_description/launch/visualize_robot_gripper.launch
+++ b/osr_description/launch/visualize_robot_gripper.launch
@@ -1,11 +1,8 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="gui" default="True" />
-  
   <param name="robot_description" command="$(find xacro)/xacro --inorder $(find osr_description)/urdf/denso_robotiq_85_gripper.urdf.xacro" />
   
-  <param name="use_gui" value="$(arg gui)"/>
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
   

--- a/osr_description/package.xml
+++ b/osr_description/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>joint_state_publisher</run_depend>
+  <run_depend>joint_state_publisher_gui</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>robotiq_description</run_depend>
   <run_depend>xacro</run_depend>


### PR DESCRIPTION
Based on the split of `joint_state_publisher`'s GUI component as referenced [here](https://github.com/ros/joint_state_publisher/pull/31).